### PR TITLE
Add NuGet package metadata and CI configuration for publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,7 @@ script:
   - mozroots --import --ask-remove
   - xbuild NetLicensingClient.sln
   - mono NetLicensingClient-demo/bin/Debug/NetLicensingClient-demo.exe
+  - mkdir .nuget
+  - curl https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -o ./.nuget/nuget.exe
+  - mono ./.nuget/nuget.exe pack "./NetLicensingClient/NetLicensingClient.csproj" -Build -Symbols -Properties Configuration=Release -OutputFileNamesWithoutVersion -OutputDirectory "./NetLicensingClient/bin/Release/"
+  - mono ./.nuget/nuget.exe push "./NetLicensingClient/bin/Release/NetLicensingClient.nupkg" -ApiKey $NUGET_PUSH_KEY -Source "https://api.nuget.org/v3/index.json" -SkipDuplicate

--- a/NetLicensingClient/NetLicensingClient.nuspec
+++ b/NetLicensingClient/NetLicensingClient.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
+    <license type="expression">Apache-2.0</license>
+    <projectUrl>https://github.com/Labs64/NetLicensingClient-csharp</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>$description$</description>
+    <releaseNotes>Initial NuGet release</releaseNotes>
+    <copyright>Copyright 2019</copyright>
+    <tags>labs64 netlicensing license license-management licensing activation wrapper c-sharp</tags>
+  </metadata>
+</package>


### PR DESCRIPTION
This adds NuGet package support and CI steps to pack and publish it on NuGet.

Downloading `nuget.exe` is necessary due to different supported versions on Travis.

Open issues:
 - Travis-CI build on linux machines does not work
 - Needs another package identifier for publishing as Labs64

Addresses #10 